### PR TITLE
♻️ Update Move's PieceType after PGN mapping

### DIFF
--- a/pax.chess.tests/BasicTests.cs
+++ b/pax.chess.tests/BasicTests.cs
@@ -148,10 +148,22 @@ namespace pax.chess.tests
         {
             var game = Pgn.MapString("1. g4 h5 2. gxh5 a6 3. h6 d6 4. h7 c6");
             var move = Map.GetEngineMove("h7g8Q");
-            if (move is null) throw new ArgumentNullException();
+            ArgumentNullException.ThrowIfNull(move);
             var state = game.Move(move);
             var pgn = Pgn.MapPieces(game.State);
             Assert.Equal("1. g4 h5 2. gxh5 a6 3. h6 d6 4. h7 c6 5. hxg8=Q ", pgn);
+        }
+        
+        [Fact]
+        public void PawnPromote_PieceBecomesQueen()
+        {
+            var game = Pgn.MapString("1. g4 h5 2. gxh5 a6 3. h6 d6 4. h7 c6");
+            var move = Map.GetEngineMove("h7g8Q");
+            ArgumentNullException.ThrowIfNull(move);
+            var state = game.Move(move);
+            var pieces = game.State.Pieces;
+            var promotedPiece = pieces.Single(p => p.Position == new Position(6, 7));
+            Assert.Equal(PieceType.Queen, promotedPiece.Type);
         }
     }
 }

--- a/src/pax.chess/State.cs
+++ b/src/pax.chess/State.cs
@@ -86,7 +86,14 @@ public record State
                 Pieces.Remove(move.Capture);
             }
         }
+        
         move.PgnMove = Pgn.MapPiece(move, this);
+        
+        // Handle promotion, after generating the PGN
+        if (move.Transformation is not null)
+        {
+            move.Piece.Type = move.Transformation.Value;
+        }
 
         move.Piece.Position = move.NewPosition;
 


### PR DESCRIPTION
My previous PR broke accurate game state after promotion - pawn's did not become the promotion piece type, despite fixing the PGN mapping.

It is hard to represent both a move, and the game's state accurately in regards to promotions, since changing the piece type of a Piece in a Move is technically incorrect (a queen did not make the move), but is necessary to be changed to the promotion piece type, e.g. Queen, since the piece is also referenced in the Game.State. 

There are two solutions for this specific problem (accurate PGN whilst also updating the piece type to represent the game state.)

1. Map the PGN, then update the piece type
2. Update the PGN mapping code to handle a promotion (e.g. hxg8=Q, instead of Qxg8), despite the piece type being a Queen.

I have implemented the first solution 😅 I'm happy to do the second instead if that is preferable.